### PR TITLE
feat: add GET /api/v1/books/{book_id} endpoint

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+env/
+__pycache__/
+
+*.env
+*.env.*
+env.*

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: CD Pipeline to Google Cloud Run(Staging/Production)
+name: CD Pipeline to Google Compute Engine(Staging/Production)
 
 on:
   push:
@@ -28,24 +28,33 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Authenticate with GCP
-        uses: google-github-actions/auth@v2
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
         with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          export_default_credentials: true
 
-      - name: Configure Docker
+      - name: Authenticate Docker to GCR
         run: |
-          gcloud auth configure-docker $REGION-docker.pkg.dev
+          echo ${{ secrets.GCP_SA_KEY }} | docker login -u _json_key --password-stdin https://gcr.io
 
-      - name: Build & Push Docker Image
+      - name: Build and push Docker image
         run: |
-          gcloud builds submit --tag $REGION-docker.pkg.dev/$PROJECT_ID/$REPO/$SERVICE_NAME:latest .
+          IMAGE_NAME=gcr.io/${{ secrets.GCP_PROJECT_ID }}/fastapi-app:latest
+          docker build -t $IMAGE_NAME .
+          docker push $IMAGE_NAME
 
-      - name: Deploy to Cloud Run
-        run: |
-          gcloud run deploy $SERVICE_NAME \
-            --image $REGION-docker.pkg.dev/$PROJECT_ID/$REPO/$SERVICE_NAME:latest \
-            --region $REGION \
-            --platform managed \
-            --allow-unauthenticated
-            --port 80
+      - name: Deploy to Compute Engine via SSH
+        uses: appleboy/ssh-action@v0.1.5
+        with:
+          host: ${{ secrets.COMPUTE_ENGINE_IP }}
+          username: ${{ secrets.COMPUTE_ENGINE_USER }}
+          key: ${{ secrets.COMPUTE_ENGINE_SSH_KEY }}
+          port: 22
+          script: |
+            cd /opt/fastapi-deployment
+            git clone https://github.com/onyx093/fastapi-book-project .
+            # (Optional) Update the docker-compose file to use the latest image if necessary.
+            # docker-compose pull
+            docker-compose up -d

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,51 @@
+name: CD Pipeline to Google Cloud Run(Staging/Production)
+
+on:
+  push:
+    branches:
+      - main
+env:
+  PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+  REGION: us-central1
+  REPO: fastapi-book-project
+  SERVICE_NAME: fastapi-book-project-cloud-run
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Authenticate with GCP
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Configure Docker
+        run: |
+          gcloud auth configure-docker $REGION-docker.pkg.dev
+
+      - name: Build & Push Docker Image
+        run: |
+          gcloud builds submit --tag $REGION-docker.pkg.dev/$PROJECT_ID/$REPO/$SERVICE_NAME:latest .
+
+      - name: Deploy to Cloud Run
+        run: |
+          gcloud run deploy $SERVICE_NAME \
+            --image $REGION-docker.pkg.dev/$PROJECT_ID/$REPO/$SERVICE_NAME:latest \
+            --region $REGION \
+            --platform managed \
+            --allow-unauthenticated
+            --port 80

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: CI Pipeline to staging/production environments
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run Tests
+        run: |
+          pytest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.12.9-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY requirements.txt .
+
+RUN pip install --upgrade pip && \
+    pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/api/routes/books.py
+++ b/api/routes/books.py
@@ -1,6 +1,6 @@
 from typing import OrderedDict
 
-from fastapi import APIRouter, status
+from fastapi import APIRouter, HTTPException, status
 from fastapi.responses import JSONResponse
 
 from api.db.schemas import Book, Genre, InMemoryDB
@@ -47,6 +47,16 @@ async def create_book(book: Book):
 async def get_books() -> OrderedDict[int, Book]:
     return db.get_books()
 
+
+@router.get("/{book_id}", response_model=Book, status_code=status.HTTP_200_OK)
+async def get_book(book_id: int) -> Book:
+    for book in db.books.values():
+        if book.id == book_id:
+            return JSONResponse(
+                status_code=status.HTTP_200_OK,
+                content=db.get_book(book_id).model_dump(),
+            )
+    raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Book not found")
 
 @router.put("/{book_id}", response_model=Book, status_code=status.HTTP_200_OK)
 async def update_book(book_id: int, book: Book) -> Book:

--- a/api/routes/books.py
+++ b/api/routes/books.py
@@ -50,13 +50,13 @@ async def get_books() -> OrderedDict[int, Book]:
 
 @router.get("/{book_id}", response_model=Book, status_code=status.HTTP_200_OK)
 async def get_book(book_id: int) -> Book:
-    for book in db.books.values():
-        if book.id == book_id:
-            return JSONResponse(
-                status_code=status.HTTP_200_OK,
-                content=db.get_book(book_id).model_dump(),
-            )
-    raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Book not found")
+    book = db.get_book(book_id)
+    if not book:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Book not found")
+    return JSONResponse(
+        status_code=status.HTTP_200_OK,
+        content=book.model_dump(),
+    )
 
 @router.put("/{book_id}", response_model=Book, status_code=status.HTTP_200_OK)
 async def update_book(book_id: int, book: Book) -> Book:

--- a/compose.yml
+++ b/compose.yml
@@ -7,6 +7,7 @@ services:
       - '8000:8000'
     volumes:
       - .:/app
+    restart: always
 
   nginx:
     image: nginx:latest
@@ -16,3 +17,4 @@ services:
       - ./nginx.conf:/etc/nginx/conf.d/default.conf
     depends_on:
       - server
+    restart: always

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,18 @@
+version: '3.8'
+
+services:
+  server:
+    build: .
+    ports:
+      - '8000:8000'
+    volumes:
+      - .:/app
+
+  nginx:
+    image: nginx:latest
+    ports:
+      - '80:80'
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf
+    depends_on:
+      - server

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,11 @@
+server {
+    listen 80;
+    server_name http://localhost;
+    location / {
+        proxy_pass http://server:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,6 +1,6 @@
 server {
     listen 80;
-    server_name http://localhost;
+    
     location / {
         proxy_pass http://server:8000;
         proxy_set_header Host $host;


### PR DESCRIPTION
## Description  
- Added GET `/api/v1/books/{book_id}` endpoint to retrieve book details.
- Configures nginx server for reverse proxy
- Configures CI pipeline on pull request changes
- Configures CD pipeline for automatic deployment to Google Compute Engine

## Related Task  
[HNG12 Stage 2 Task](https://github.com/hng12-devbot/fastapi-book-project)  

## Testing  
- Ran `pytest` locally (all tests passed).  
- Tested invalid IDs (e.g., `/books/999`) to confirm 404 response.  

## Notes  
- Installed `hng12-devbot2` as a app into the repo.  
- Deployment URL: `https://34.57.109.91/`

1. Configures nginx server for reverse proxy
2. Configures CI pipeline on pull request changes
3. Configures CD pipeline for automatic deployment to Google Compute Engine