### PR TITLE
fix: cd pipeline corrections for compute engine deployment v9

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,8 +43,13 @@ jobs:
           key: ${{ secrets.COMPUTE_ENGINE_SSH_KEY }}
           port: 22
           script: |
+            # cd /opt/
+            # sudo rm -rf ./fastapi-deployment/
+            # sudo mkdir -p /opt/fastapi-deployment
+            # sudo chown $USER:$USER /opt/fastapi-deployment
+
             cd /opt/fastapi-deployment
-            git clone git@github.com:onyx093/fastapi-book-project.git .
+            git pull origin main
             # (Optional) Update the docker-compose file to use the latest image if necessary.
             # docker-compose pull && docker compose down aith others
             docker compose up -d


### PR DESCRIPTION
## Description  
- Added GET `/api/v1/books/{book_id}` endpoint to retrieve book details.
- Configures nginx server for reverse proxy
- Configures CI pipeline on pull request changes
- Configures CD pipeline for automatic deployment to Google Compute Engine

## Related Task  
[HNG12 Stage 2 Task](https://github.com/hng12-devbot/fastapi-book-project)  

## Testing  
- Ran `pytest` locally (all tests passed).  
- Tested invalid IDs (e.g., `/books/999`) to confirm 404 response.  

## Notes  
- Installed `hng12-devbot2` as a app into the repo.  
- Deployment URL: `https://34.57.109.91/`

1. Configures nginx server for reverse proxy
2. Configures CI pipeline on pull request changes
3. Configures CD pipeline for automatic deployment to Google Compute Engine