### PR TITLE
fix: cd pipeline corrections for compute engine deployment v15

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,8 @@ jobs:
             # sudo chown $USER:$USER /opt/fastapi-deployment
 
             cd /opt/fastapi-deployment
-            git pull origin main
+            git fetch origin main
+            git reset --hard origin/main
             # (Optional) Update the docker-compose file to use the latest image if necessary.
             # docker-compose pull && docker compose down with others
             sudo docker-compose up --detach

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,6 +1,5 @@
 server {
     listen 80;
-    server_name http://34.57.109.91/;
     
     location / {
         proxy_pass http://server:8000;


### PR DESCRIPTION
## Description  
- Added GET `/api/v1/books/{book_id}` endpoint to retrieve book details.
- Configures nginx server for reverse proxy
- Configures CI pipeline on pull request changes
- Configures CD pipeline for automatic deployment to Google Compute Engine

## Related Task  
[HNG12 Stage 2 Task](https://github.com/hng12-devbot/fastapi-book-project)  

## Testing  
- Ran `pytest` locally (all tests passed).  
- Tested invalid IDs (e.g., `/books/999`) to confirm 404 response.  

## Notes  
- Installed `hng12-devbot2` as a app into the repo.  
- Deployment URL: `https://34.57.109.91/`

1. Configures nginx server for reverse proxy
2. Configures CI pipeline on pull request changes
3. Configures CD pipeline for automatic deployment to Google Compute Engine